### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Fayeblade1488/Faye-Blade_Qwencode_venice_gitkraken/security/code-scanning/7](https://github.com/Fayeblade1488/Faye-Blade_Qwencode_venice_gitkraken/security/code-scanning/7)

To fix this issue, add an explicit `permissions` block setting the minimal permissions necessary to complete the job (read access to contents) at either the root level (for the whole workflow) or specifically within the `test` job (for this job only). Since there is only one job, and no evidence of workflows requiring more than read access, adding at the root is both sufficient and clear. This requires editing the `.github/workflows/tests.yml` file by adding:

```yaml
permissions:
  contents: read
```

after the workflow name (`name: Tests`) and before the `on:` block, following best practices and YAML conventions. No imports or new dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
